### PR TITLE
Constrain handler types (issue #51)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+nodejs lts-gallium

--- a/README.md
+++ b/README.md
@@ -11,34 +11,57 @@ This patten is generally used to bypass the maximum AWS API Gateway/Lambda Proxy
 
 The idea is you can use the HTTP to submit a request that will trigger a long-running Lambda. This call will immediately return a response with a HTTP GET URL that allows you to query the status of the task.
 
-Usage is demonstrated in the example projects in the examples folder.
+Usage is demonstrated in the example projects in the [examples folder](./examples).
 
 Usually it would be as simple as adding the following line to your serverless definition file:
 
 ```typescript
-  // serverless.ts
-  plugins: [
-    '@agiledigital/aws-durable-lambda'
-  ]
+// serverless.ts
+plugins: ["@agiledigital/aws-durable-lambda"];
 ```
 
 ```yaml
-  # serverless.yaml
-  plugins:
-  - '@agiledigital/aws-durable-lambda'
+# serverless.yaml
+plugins:
+  - "@agiledigital/aws-durable-lambda"
 ```
 
 Then you can call your lambda using the automatically generated "create-task" endpoint.
 
 ```
-POST https://{api gateway endpoint}/create-task/{full name of the function to invoke}
+POST https://{api gateway endpoint}/create-task/{full name of the function to invoke} -d '{ optional: "payload" }'
 ```
 
 The above POST will return a HTTP URL for you to query the task status.
 
+Calling that will give you a payload like the following:
+
+```json
+{
+  "SubmittedAt": "2022-07-27T11:14:37.251Z",
+  "FunctionName": "adl-example-serverless-esbuild-sandbox-myFunction",
+  "Status": "Processing",
+  "ID": "6f7ca34a-8de6-434f-9337-763d2a075566"
+}
+```
+
+Eventually when you task is complete, the task status query will return something like the following.
+
+```json
+{
+  "SubmittedAt": "2022-07-27T11:14:37.251Z",
+  "FunctionName": "adl-example-serverless-esbuild-sandbox-myFunction",
+  "FinishedAt": "2022-07-27T11:14:48.343Z",
+  "Response": "{\"message\":\"Finished long journey\",\"transformedInput\":\"HELLO WORLD!\"}",
+  "StartedAt": "2022-07-27T11:14:37.949Z",
+  "Status": "Completed",
+  "ID": "6f7ca34a-8de6-434f-9337-763d2a075566"
+}
+```
+
 ## Testing
 
-As we need to inject the required infrastructure into an existing serverless project, 
+As we need to inject the required infrastructure into an existing serverless project,
 the main source of issues will be the interaction with the different bundler/packager
 configurations.
 
@@ -50,8 +73,8 @@ There is currently an automatic CI job that packages each example to ensure that
 that there are no packaging errors. However the automatic CI job does not deploy
 the example to AWS or do any integration testing.
 
-To test it more thoroughly, you can deploy each example individually, 
-or you can use the "examples/deploy-all.sh" to automatically build the plugin, 
+To test it more thoroughly, you can deploy each example individually,
+or you can use the "examples/deploy-all.sh" to automatically build the plugin,
 and deploy all the examples.
 
 ```bash
@@ -81,7 +104,6 @@ curl -s -H 'API_KEY: ${API_KEY}' "${STATUS_URL}" | jq -r ".[0].Status"`
 ```
 
 This is currently a manual process, however we hope to automate this in the future.
-
 
 [ico-build]: https://github.com/agiledigital-labs/aws-durable-lambda/actions/workflows/package.yml/badge.svg
 [ico-serverless]: http://public.serverless.com/badges/v3.svg

--- a/examples/serverless-esbuild/src/functions/myFunction/handler.ts
+++ b/examples/serverless-esbuild/src/functions/myFunction/handler.ts
@@ -1,16 +1,27 @@
+import type { TaskEvent, TaskHandler } from '@agiledigital/aws-durable-lambda';
 
 const dummyLongRunningProcessTimeInMillis = 10 * 1000;
 
-const dummyLongRunningProcess = () => new Promise((resolve) => {
-  setTimeout(() => resolve({ message: 'Finished long journey' }), dummyLongRunningProcessTimeInMillis);
-})
+const dummyLongRunningProcess = () =>
+  new Promise((resolve) => {
+    setTimeout(
+      () => resolve({ message: 'Finished long journey' }),
+      dummyLongRunningProcessTimeInMillis
+    );
+  });
 
-const myFunction = async (event: unknown) => {
-  console.log("Received event", event);
+/**
+ * Called by aws-durable-lambda when a new task is submitted.
+ *
+ * @param event the event object provided by aws-durable-lambda
+ * @returns result the result to store against the task record when it completes
+ */
+const myFunction: TaskHandler = async (event: TaskEvent) => {
+  console.log('Received event', event);
 
   const result = await dummyLongRunningProcess();
 
   return result;
-}
+};
 
 export const main = myFunction;

--- a/examples/serverless-esbuild/src/functions/myFunction/handler.ts
+++ b/examples/serverless-esbuild/src/functions/myFunction/handler.ts
@@ -1,11 +1,21 @@
 import type { TaskEvent, TaskHandler } from '@agiledigital/aws-durable-lambda';
 
+/**
+ * Payload that is specific to this task and is passed
+ * in when createTask is called.
+ */
+type TaskPayload = { input: string };
+
 const dummyLongRunningProcessTimeInMillis = 10 * 1000;
 
-const dummyLongRunningProcess = () =>
+const dummyLongRunningProcess = (input: string) =>
   new Promise((resolve) => {
     setTimeout(
-      () => resolve({ message: 'Finished long journey' }),
+      () =>
+        resolve({
+          message: 'Finished long journey',
+          transformedInput: input.toLocaleUpperCase(),
+        }),
       dummyLongRunningProcessTimeInMillis
     );
   });
@@ -16,10 +26,10 @@ const dummyLongRunningProcess = () =>
  * @param event the event object provided by aws-durable-lambda
  * @returns result the result to store against the task record when it completes
  */
-const myFunction: TaskHandler = async (event: TaskEvent) => {
+const myFunction: TaskHandler = async (event: TaskEvent<TaskPayload>) => {
   console.log('Received event', event);
 
-  const result = await dummyLongRunningProcess();
+  const result = await dummyLongRunningProcess(event.requestPayload.input);
 
   return result;
 };

--- a/examples/serverless-esbuild/src/functions/myFunction/index.ts
+++ b/examples/serverless-esbuild/src/functions/myFunction/index.ts
@@ -3,5 +3,5 @@ import { handlerPath } from '../../handlerResolver';
 export default {
   handler: `${handlerPath(__dirname)}/handler.main`,
   timeout: 900,
-  events: []
-}
+  events: [],
+};

--- a/examples/serverless-jetpack/src/functions/myFunction/handler.js
+++ b/examples/serverless-jetpack/src/functions/myFunction/handler.js
@@ -1,18 +1,30 @@
+import { TaskEvent, TaskHandler } from '@agiledigital/aws-durable-lambda';
 
 const dummyLongRunningProcessTimeInMillis = 10 * 1000;
 
-const dummyLongRunningProcess = () => new Promise((resolve) => {
-  setTimeout(() => resolve({ message: 'Finished long journey' }), dummyLongRunningProcessTimeInMillis);
-})
+const dummyLongRunningProcess = () =>
+  new Promise((resolve) => {
+    setTimeout(
+      () => resolve({ message: 'Finished long journey' }),
+      dummyLongRunningProcessTimeInMillis
+    );
+  });
 
+/**
+ * Called by aws-durable-lambda when a new task is submitted.
+ *
+ * @type TaskHandler
+ * @param {TaskEvent} event the event object provided by aws-durable-lambda
+ * @returns result the result to store against the task record when it completes
+ */
 const myFunction = async (event) => {
-  console.log("Received event", event);
+  console.log('Received event', event);
 
   const result = await dummyLongRunningProcess();
 
   return result;
-}
+};
 
 module.exports = {
-  main: myFunction
-}
+  main: myFunction,
+};

--- a/examples/serverless-jetpack/src/functions/myFunction/handler.js
+++ b/examples/serverless-jetpack/src/functions/myFunction/handler.js
@@ -1,11 +1,21 @@
-import { TaskEvent, TaskHandler } from '@agiledigital/aws-durable-lambda';
+/**
+ * Type imports for jsdoc which provide intellisense assistance in VSCode
+ * even without TypeScript
+ * See https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#import-types
+ * @typedef { import('@agiledigital/aws-durable-lambda').TaskEvent } TaskEvent
+ * @typedef { import('@agiledigital/aws-durable-lambda').TaskHandler } TaskHandler
+ */
 
 const dummyLongRunningProcessTimeInMillis = 10 * 1000;
 
-const dummyLongRunningProcess = () =>
+const dummyLongRunningProcess = (input) =>
   new Promise((resolve) => {
     setTimeout(
-      () => resolve({ message: 'Finished long journey' }),
+      () =>
+        resolve({
+          message: 'Finished long journey',
+          transformedInput: input.toLocaleUpperCase(),
+        }),
       dummyLongRunningProcessTimeInMillis
     );
   });
@@ -14,13 +24,13 @@ const dummyLongRunningProcess = () =>
  * Called by aws-durable-lambda when a new task is submitted.
  *
  * @type TaskHandler
- * @param {TaskEvent} event the event object provided by aws-durable-lambda
+ * @param {TaskEvent<{ input: string }>} event the event object provided by aws-durable-lambda
  * @returns result the result to store against the task record when it completes
  */
 const myFunction = async (event) => {
   console.log('Received event', event);
 
-  const result = await dummyLongRunningProcess();
+  const result = await dummyLongRunningProcess(event.requestPayload.input);
 
   return result;
 };

--- a/examples/serverless-webpack/src/functions/myFunction/handler.ts
+++ b/examples/serverless-webpack/src/functions/myFunction/handler.ts
@@ -1,16 +1,27 @@
+import type { TaskEvent, TaskHandler } from '@agiledigital/aws-durable-lambda';
 
 const dummyLongRunningProcessTimeInMillis = 10 * 1000;
 
-const dummyLongRunningProcess = () => new Promise((resolve) => {
-  setTimeout(() => resolve({ message: 'Finished long journey' }), dummyLongRunningProcessTimeInMillis);
-})
+const dummyLongRunningProcess = () =>
+  new Promise((resolve) => {
+    setTimeout(
+      () => resolve({ message: 'Finished long journey' }),
+      dummyLongRunningProcessTimeInMillis
+    );
+  });
 
-const myFunction = async (event: unknown) => {
-  console.log("Received event", event);
+/**
+ * Called by aws-durable-lambda when a new task is submitted.
+ *
+ * @param event the event object provided by aws-durable-lambda
+ * @returns result the result to store against the task record when it completes
+ */
+const myFunction: TaskHandler = async (event: TaskEvent) => {
+  console.log('Received event', event);
 
   const result = await dummyLongRunningProcess();
 
   return result;
-}
+};
 
 export const main = myFunction;

--- a/examples/serverless-webpack/src/functions/myFunction/handler.ts
+++ b/examples/serverless-webpack/src/functions/myFunction/handler.ts
@@ -1,11 +1,21 @@
 import type { TaskEvent, TaskHandler } from '@agiledigital/aws-durable-lambda';
 
+/**
+ * Payload that is specific to this task and is passed
+ * in when createTask is called.
+ */
+type TaskPayload = { input: string };
+
 const dummyLongRunningProcessTimeInMillis = 10 * 1000;
 
-const dummyLongRunningProcess = () =>
+const dummyLongRunningProcess = (input: string) =>
   new Promise((resolve) => {
     setTimeout(
-      () => resolve({ message: 'Finished long journey' }),
+      () =>
+        resolve({
+          message: 'Finished long journey',
+          transformedInput: input.toLocaleUpperCase(),
+        }),
       dummyLongRunningProcessTimeInMillis
     );
   });
@@ -16,10 +26,10 @@ const dummyLongRunningProcess = () =>
  * @param event the event object provided by aws-durable-lambda
  * @returns result the result to store against the task record when it completes
  */
-const myFunction: TaskHandler = async (event: TaskEvent) => {
+const myFunction: TaskHandler = async (event: TaskEvent<TaskPayload>) => {
   console.log('Received event', event);
 
-  const result = await dummyLongRunningProcess();
+  const result = await dummyLongRunningProcess(event.requestPayload.input);
 
   return result;
 };

--- a/examples/spt/src/functions/myFunction/handler.ts
+++ b/examples/spt/src/functions/myFunction/handler.ts
@@ -1,16 +1,27 @@
+import type { TaskEvent, TaskHandler } from '@agiledigital/aws-durable-lambda';
 
 const dummyLongRunningProcessTimeInMillis = 10 * 1000;
 
-const dummyLongRunningProcess = () => new Promise((resolve) => {
-  setTimeout(() => resolve({ message: 'Finished long journey' }), dummyLongRunningProcessTimeInMillis);
-})
+const dummyLongRunningProcess = () =>
+  new Promise((resolve) => {
+    setTimeout(
+      () => resolve({ message: 'Finished long journey' }),
+      dummyLongRunningProcessTimeInMillis
+    );
+  });
 
-const myFunction = async (event: unknown) => {
-  console.log("Received event", event);
+/**
+ * Called by aws-durable-lambda when a new task is submitted.
+ *
+ * @param event the event object provided by aws-durable-lambda
+ * @returns result the result to store against the task record when it completes
+ */
+const myFunction: TaskHandler = async (event: TaskEvent) => {
+  console.log('Received event', event);
 
   const result = await dummyLongRunningProcess();
 
   return result;
-}
+};
 
 export const main = myFunction;

--- a/examples/spt/src/functions/myFunction/handler.ts
+++ b/examples/spt/src/functions/myFunction/handler.ts
@@ -34,4 +34,4 @@ const myFunction: TaskHandler = async (event: TaskEvent<TaskPayload>) => {
   return result;
 };
 
-export const main = myFunction;
+module.exports.main = myFunction;

--- a/examples/spt/src/functions/myFunction/handler.ts
+++ b/examples/spt/src/functions/myFunction/handler.ts
@@ -1,11 +1,21 @@
 import type { TaskEvent, TaskHandler } from '@agiledigital/aws-durable-lambda';
 
+/**
+ * Payload that is specific to this task and is passed
+ * in when createTask is called.
+ */
+type TaskPayload = { input: string };
+
 const dummyLongRunningProcessTimeInMillis = 10 * 1000;
 
-const dummyLongRunningProcess = () =>
+const dummyLongRunningProcess = (input: string) =>
   new Promise((resolve) => {
     setTimeout(
-      () => resolve({ message: 'Finished long journey' }),
+      () =>
+        resolve({
+          message: 'Finished long journey',
+          transformedInput: input.toLocaleUpperCase(),
+        }),
       dummyLongRunningProcessTimeInMillis
     );
   });
@@ -16,10 +26,10 @@ const dummyLongRunningProcess = () =>
  * @param event the event object provided by aws-durable-lambda
  * @returns result the result to store against the task record when it completes
  */
-const myFunction: TaskHandler = async (event: TaskEvent) => {
+const myFunction: TaskHandler = async (event: TaskEvent<TaskPayload>) => {
   console.log('Received event', event);
 
-  const result = await dummyLongRunningProcess();
+  const result = await dummyLongRunningProcess(event.requestPayload.input);
 
   return result;
 };

--- a/examples/spt/src/functions/myFunction/index.ts
+++ b/examples/spt/src/functions/myFunction/index.ts
@@ -3,5 +3,5 @@ import { handlerPath } from '../../handlerResolver';
 export default {
   handler: `${handlerPath(__dirname)}/handler.main`,
   timeout: 900,
-  events: []
-}
+  events: [],
+};

--- a/examples/spt/tsconfig.json
+++ b/examples/spt/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.paths.json",
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["ES2020"],
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -9,10 +9,11 @@
     "sourceMap": true,
     "target": "ES2020",
     "outDir": "lib",
+    "module": "CommonJS",
     // The aws-durable-lambda plugin is packaged as js, so we need to allow
     // the compiler to pull in js
     // TODO: Will this be annoying to consumers of the plugin? Is there a way to get it to package without compiling?
-    "allowJs": true,
+    "allowJs": true
   },
   "include": ["src/**/*.ts", "serverless.ts"],
   "exclude": [

--- a/examples/validate-all.sh
+++ b/examples/validate-all.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+source './assert.sh'
 #
 # Runs through each example deployed with "deploy-all.sh" and 
 # gives each a smoke test by calling the deployed API and checking
@@ -36,17 +37,22 @@ do
     echo "API key retrieved."
 
     API_BASE_URL="https://${API_ID}.execute-api.${REGION}.amazonaws.com/${STAGE}"
-    STATUS_URL=`curl --fail --silent --show-error -X POST -H 'API_KEY: ${API_KEY}' "${API_BASE_URL}/create-task/${API_NAME}-myFunction" | jq -r ".statusUrl"`
+    STATUS_URL=`curl --fail --silent --show-error -X POST -H 'API_KEY: ${API_KEY}' "${API_BASE_URL}/create-task/${API_NAME}-myFunction" -d '{ "input": "hello world!" }' | jq -r ".statusUrl"`
     
     echo "Polling for status every [${POLL_PERIOD}] seconds..."
     
     STATUS="Unknown"
     TARGET_STATUS="Completed"
+    TARGET_RESPONSE="HELLO WORLD!"
     until [ "$STATUS" == "Completed" ]
     do
         sleep "${POLL_PERIOD}"
-        STATUS=`curl --fail --silent --show-error -H 'API_KEY: ${API_KEY}' "${STATUS_URL}" | jq -r ".[0].Status"`
+        TASK_DATA=`curl --fail --silent --show-error -H 'API_KEY: ${API_KEY}' "${STATUS_URL}"`
+        STATUS=`jq -r ".[0].Status" <<< "${TASK_DATA}"`
+        RESPONSE=`jq -r ".[0].Response // empty | fromjson | .transformedInput" <<< "${TASK_DATA}"`
         echo "Status is: '${STATUS}'. Waiting for '${TARGET_STATUS}'"
     done
-    echo "Status is '${TARGET_STATUS}'. Looks like the durable lambda is working!"
+    echo "Status is '${TARGET_STATUS}'. Looks like the durable lambda completed. Verifying response..."
+    assert_eq "$RESPONSE" "$TARGET_RESPONSE" "Response should be the input payload in uppercase"
+    echo "Response looks OK!"
 done

--- a/examples/vanilla/src/functions/myFunction/handler.js
+++ b/examples/vanilla/src/functions/myFunction/handler.js
@@ -1,18 +1,30 @@
+import { TaskEvent, TaskHandler } from '@agiledigital/aws-durable-lambda';
 
 const dummyLongRunningProcessTimeInMillis = 10 * 1000;
 
-const dummyLongRunningProcess = () => new Promise((resolve) => {
-  setTimeout(() => resolve({ message: 'Finished long journey' }), dummyLongRunningProcessTimeInMillis);
-})
+const dummyLongRunningProcess = () =>
+  new Promise((resolve) => {
+    setTimeout(
+      () => resolve({ message: 'Finished long journey' }),
+      dummyLongRunningProcessTimeInMillis
+    );
+  });
 
+/**
+ * Called by aws-durable-lambda when a new task is submitted.
+ *
+ * @type TaskHandler
+ * @param {TaskEvent} event the event object provided by aws-durable-lambda
+ * @returns result the result to store against the task record when it completes
+ */
 const myFunction = async (event) => {
-  console.log("Received event", event);
+  console.log('Received event', event);
 
   const result = await dummyLongRunningProcess();
 
   return result;
-}
+};
 
 module.exports = {
-  main: myFunction
-}
+  main: myFunction,
+};

--- a/examples/vanilla/src/functions/myFunction/handler.js
+++ b/examples/vanilla/src/functions/myFunction/handler.js
@@ -1,11 +1,21 @@
-import { TaskEvent, TaskHandler } from '@agiledigital/aws-durable-lambda';
+/**
+ * Type imports for jsdoc which provide intellisense assistance in VSCode
+ * even without TypeScript
+ * See https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#import-types
+ * @typedef { import('@agiledigital/aws-durable-lambda').TaskEvent } TaskEvent
+ * @typedef { import('@agiledigital/aws-durable-lambda').TaskHandler } TaskHandler
+ */
 
 const dummyLongRunningProcessTimeInMillis = 10 * 1000;
 
-const dummyLongRunningProcess = () =>
+const dummyLongRunningProcess = (input) =>
   new Promise((resolve) => {
     setTimeout(
-      () => resolve({ message: 'Finished long journey' }),
+      () =>
+        resolve({
+          message: 'Finished long journey',
+          transformedInput: input.toLocaleUpperCase(),
+        }),
       dummyLongRunningProcessTimeInMillis
     );
   });
@@ -14,13 +24,13 @@ const dummyLongRunningProcess = () =>
  * Called by aws-durable-lambda when a new task is submitted.
  *
  * @type TaskHandler
- * @param {TaskEvent} event the event object provided by aws-durable-lambda
+ * @param {TaskEvent<{ input: string }>} event the event object provided by aws-durable-lambda
  * @returns result the result to store against the task record when it completes
  */
 const myFunction = async (event) => {
   console.log('Received event', event);
 
-  const result = await dummyLongRunningProcess();
+  const result = await dummyLongRunningProcess(event.requestPayload.input);
 
   return result;
 };

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -3,14 +3,15 @@
   "version": "1.0.0",
   "description": "A Serverless plugin to automate using AWS SQS, AWS DynamoDB to achieve a durable function",
   "main": "lib/aws-durable-lambda.js",
+  "types": "lib/libs/types.d.ts",
   "files": [
     "lib/**/*"
   ],
   "scripts": {
     "prepare": "run-s build",
     "build": "rimraf ./lib && tsc && node ./esbuild.config.js",
-    "format": "prettier --write src/**/*.js src/**/*.ts",
-    "format-check": "prettier --check src/**/*.js src/**/*.ts"
+    "format": "prettier --write src",
+    "format-check": "prettier --check src"
   },
   "engines": {
     "node": ">=14.15.0"

--- a/plugin/src/functions/getTask/handler.ts
+++ b/plugin/src/functions/getTask/handler.ts
@@ -7,9 +7,11 @@ const getTask = async (event: APIGatewayEvent) => {
 
     console.log(taskId, event.pathParameters);
 
-    const result = await functionTaskTable.query({
-      ID: taskId
-    }).exec();
+    const result = await functionTaskTable
+      .query({
+        ID: taskId,
+      })
+      .exec();
 
     return {
       statusCode: 200,
@@ -24,13 +26,13 @@ const getTask = async (event: APIGatewayEvent) => {
     return {
       statusCode: 500,
       body: JSON.stringify({
-        message: e.message
+        message: e.message,
       }),
       headers: {
         'Content-Type': 'application/json',
       },
     };
   }
-}
+};
 
 export const main = getTask;

--- a/plugin/src/functions/getTask/index.ts
+++ b/plugin/src/functions/getTask/index.ts
@@ -6,8 +6,8 @@ export default {
     {
       http: {
         method: 'get',
-        path: 'task/{taskId}'
-      }
-    }
-  ]
-}
+        path: 'task/{taskId}',
+      },
+    },
+  ],
+};

--- a/plugin/src/functions/orchestrator/handler.ts
+++ b/plugin/src/functions/orchestrator/handler.ts
@@ -1,32 +1,42 @@
 import sqs from '@libs/awsSqs';
 import lambda from '@libs/lambda';
+import { TaskEvent, TaskMessageBody } from '@libs/types';
 import { SQSEvent } from 'aws-lambda';
-
-type TaskMessageBody = {
-  functionName: string;
-  taskId: string;
-}
 
 const orchestrator = async (event: SQSEvent) => {
   const messages = event.Records;
 
-  const results = await Promise.all(messages.map(async (message) => {
-    const startedAt = new Date().toISOString();
+  const results = await Promise.all(
+    messages.map(async (message) => {
+      const startedAt = new Date().toISOString();
 
-    try {
-      const body = JSON.parse(message.body) as TaskMessageBody;
+      try {
+        const body = JSON.parse(message.body) as TaskMessageBody;
+        const { functionName, taskId } = body;
+        const event: TaskEvent = {
+          taskId,
+        };
 
-      const response = await lambda.invoke({
-        FunctionName: body.functionName,
-      }).promise();
+        const response = await lambda
+          .invoke({
+            FunctionName: functionName,
+            Payload: JSON.stringify(event),
+          })
+          .promise();
 
-      const finishedAt = new Date().toISOString();
-  
-      return { ...body, response: JSON.stringify(response), startedAt, finishedAt };
-    } catch (e) {
-      return { error: true, message: e.message, startedAt };
-    }
-  }));
+        const finishedAt = new Date().toISOString();
+
+        return {
+          ...body,
+          response: JSON.stringify(response),
+          startedAt,
+          finishedAt,
+        };
+      } catch (e) {
+        return { error: true, message: e.message, startedAt };
+      }
+    })
+  );
 
   console.log('Finished processing', JSON.stringify(results, null, 2));
 

--- a/plugin/src/functions/orchestrator/handler.ts
+++ b/plugin/src/functions/orchestrator/handler.ts
@@ -40,17 +40,21 @@ const orchestrator = async (event: SQSEvent) => {
 
   console.log('Finished processing', JSON.stringify(results, null, 2));
 
-  await Promise.all(results.map(async (result) => {
-    return sqs.sendMessage({
-      QueueUrl: process.env.FUNCTION_TASK_OUTPUT_QUEUE_URL,
-      MessageBody: JSON.stringify({
-        ...result,
-        status: result.error ? 'Failed' : 'Completed'
-      })
-    }).promise();
-  }));
+  await Promise.all(
+    results.map(async (result) => {
+      return sqs
+        .sendMessage({
+          QueueUrl: process.env.FUNCTION_TASK_OUTPUT_QUEUE_URL,
+          MessageBody: JSON.stringify({
+            ...result,
+            status: result.error ? 'Failed' : 'Completed',
+          }),
+        })
+        .promise();
+    })
+  );
 
   console.log('Outputs sent to the queue');
-}
+};
 
 export const main = orchestrator;

--- a/plugin/src/functions/orchestrator/handler.ts
+++ b/plugin/src/functions/orchestrator/handler.ts
@@ -12,9 +12,10 @@ const orchestrator = async (event: SQSEvent) => {
 
       try {
         const body = JSON.parse(message.body) as TaskMessageBody;
-        const { functionName, taskId } = body;
+        const { functionName, taskId, requestPayload } = body;
         const event: TaskEvent = {
           taskId,
+          requestPayload,
         };
 
         const response = await lambda
@@ -28,7 +29,7 @@ const orchestrator = async (event: SQSEvent) => {
 
         return {
           ...body,
-          response: JSON.stringify(response),
+          response: response.Payload ?? {},
           startedAt,
           finishedAt,
         };

--- a/plugin/src/functions/orchestrator/index.ts
+++ b/plugin/src/functions/orchestrator/index.ts
@@ -7,6 +7,6 @@ export default {
     {
       sqs: { arn: { 'Fn::GetAtt': ['FunctionTaskQueue', 'Arn'] } },
       batchSize: 1,
-    }
-  ]
-}
+    },
+  ],
+};

--- a/plugin/src/functions/reporter/handler.ts
+++ b/plugin/src/functions/reporter/handler.ts
@@ -9,31 +9,36 @@ type TaskResultBody = {
   response?: string;
   startedAt?: string;
   finishedAt?: string;
-}
+};
 
 const reporter = async (event: SQSEvent) => {
   const messages = event.Records;
 
   console.log(messages);
 
-  const results = await Promise.all(messages.map(async (message) => {
-    const body = JSON.parse(message.body) as TaskResultBody;
+  const results = await Promise.all(
+    messages.map(async (message) => {
+      const body = JSON.parse(message.body) as TaskResultBody;
 
-    await functionTaskTable.update({
-      ID: body.taskId,
-      FunctionName: body.functionName
-    }, {
-      Status: body.status,
-      Message: body.message,
-      Response: body.response,
-      StartedAt: body.startedAt,
-      FinishedAt: body.finishedAt,
-    });
+      await functionTaskTable.update(
+        {
+          ID: body.taskId,
+          FunctionName: body.functionName,
+        },
+        {
+          Status: body.status,
+          Message: body.message,
+          Response: body.response,
+          StartedAt: body.startedAt,
+          FinishedAt: body.finishedAt,
+        }
+      );
 
-    return body;
-  }));
+      return body;
+    })
+  );
 
   console.log('Finished reporting', JSON.stringify(results, null, 2));
-}
+};
 
 export const main = reporter;

--- a/plugin/src/functions/reporter/index.ts
+++ b/plugin/src/functions/reporter/index.ts
@@ -7,6 +7,6 @@ export default {
     {
       sqs: { arn: { 'Fn::GetAtt': ['FunctionTaskOutputQueue', 'Arn'] } },
       batchSize: 1,
-    }
-  ]
-}
+    },
+  ],
+};

--- a/plugin/src/functions/submitTask/handler.ts
+++ b/plugin/src/functions/submitTask/handler.ts
@@ -2,6 +2,7 @@ import { functionTaskTable } from '@libs/dynamodb';
 import { APIGatewayEvent } from 'aws-lambda';
 import sqs from '../../libs/awsSqs';
 import { v4 } from 'uuid';
+import { TaskMessageBody } from '@libs/types';
 
 const submitTask = async (event: APIGatewayEvent) => {
   try {
@@ -13,13 +14,17 @@ const submitTask = async (event: APIGatewayEvent) => {
 
     const submittedAt = new Date().toISOString();
 
-    await sqs.sendMessage({
-      QueueUrl: process.env.FUNCTION_TASK_QUEUE_URL,
-      MessageBody: JSON.stringify({
-        functionName,
-        taskId
+    const body: TaskMessageBody = {
+      functionName,
+      taskId,
+    };
+
+    await sqs
+      .sendMessage({
+        QueueUrl: process.env.FUNCTION_TASK_QUEUE_URL,
+        MessageBody: JSON.stringify(body),
       })
-    }).promise();
+      .promise();
 
     await functionTaskTable.Model.create({
       ID: taskId,

--- a/plugin/src/functions/submitTask/handler.ts
+++ b/plugin/src/functions/submitTask/handler.ts
@@ -10,7 +10,12 @@ const submitTask = async (event: APIGatewayEvent) => {
 
     const taskId = v4();
 
-    const apiUrl = event.headers['X-Forwarded-Proto'] + '://' + event.headers['Host'] + '/' + event.requestContext['stage'];
+    const apiUrl =
+      event.headers['X-Forwarded-Proto'] +
+      '://' +
+      event.headers['Host'] +
+      '/' +
+      event.requestContext['stage'];
 
     const submittedAt = new Date().toISOString();
 
@@ -37,7 +42,7 @@ const submitTask = async (event: APIGatewayEvent) => {
       statusCode: 200,
       body: JSON.stringify({
         taskId,
-        statusUrl: `${apiUrl}/task/${taskId}`
+        statusUrl: `${apiUrl}/task/${taskId}`,
       }),
       headers: {
         'Content-Type': 'application/json',
@@ -49,13 +54,13 @@ const submitTask = async (event: APIGatewayEvent) => {
     return {
       statusCode: 500,
       body: JSON.stringify({
-        message: e.message
+        message: e.message,
       }),
       headers: {
         'Content-Type': 'application/json',
       },
     };
   }
-}
+};
 
 export const main = submitTask;

--- a/plugin/src/functions/submitTask/index.ts
+++ b/plugin/src/functions/submitTask/index.ts
@@ -6,8 +6,8 @@ export default {
     {
       http: {
         method: 'post',
-        path: 'create-task/{functionName}'
-      }
-    }
-  ]
-}
+        path: 'create-task/{functionName}',
+      },
+    },
+  ],
+};

--- a/plugin/src/libs/types.ts
+++ b/plugin/src/libs/types.ts
@@ -1,0 +1,43 @@
+import { Handler } from 'aws-lambda';
+
+/**
+ * The type of message that the orchestrator consumes
+ * from the task queue (published by the submitTask lambda).
+ *
+ * Does not need to be exposed outside of the aws-durable-lambda package.
+ */
+export type TaskMessageBody = {
+  /**
+   * The name of the lambda function that executes the long running task
+   * that the orchestrator should call.
+   */
+  functionName: string;
+  /**
+   * The unique ID of the aws-durable-lambda task associated with the long
+   * running task. Used to retrieve the status and result of the task.
+   */
+  taskId: string;
+};
+
+/**
+ * The event object that is passed into the lambda that the aws-durable-lambda
+ * passes into the long running lambda handler.
+ */
+export type TaskEvent = {
+  /**
+   * The unique ID of the aws-durable-lambda task that triggered the lambda.
+   * Used to retrieve the status and result of the task.
+   */
+  readonly taskId: string;
+};
+
+/**
+ * Defines the type signature of a lambda handler
+ * that will be called by the aws-durable-lambda orchestrator.
+ *
+ * The result (specified by OutputType) will be stored against the task
+ * when it completes and can be retrieved with getTask.
+ *
+ * @typeParam OutputType the type that the long running task returns
+ */
+export type TaskHandler<OutputType = unknown> = Handler<TaskEvent, OutputType>;

--- a/plugin/src/libs/types.ts
+++ b/plugin/src/libs/types.ts
@@ -12,6 +12,7 @@ export type TaskMessageBody<PayloadType = unknown> = {
    * that the orchestrator should call.
    */
   functionName: string;
+
   /**
    * The unique ID of the aws-durable-lambda task associated with the long
    * running task. Used to retrieve the status and result of the task.

--- a/plugin/src/libs/types.ts
+++ b/plugin/src/libs/types.ts
@@ -6,7 +6,7 @@ import { Handler } from 'aws-lambda';
  *
  * Does not need to be exposed outside of the aws-durable-lambda package.
  */
-export type TaskMessageBody = {
+export type TaskMessageBody<PayloadType = unknown> = {
   /**
    * The name of the lambda function that executes the long running task
    * that the orchestrator should call.
@@ -17,18 +17,29 @@ export type TaskMessageBody = {
    * running task. Used to retrieve the status and result of the task.
    */
   taskId: string;
+
+  /**
+   * The optional body passed into the submitTask function.
+   * It will be passed into the long running lambda in the event object.
+   */
+  requestPayload: PayloadType | undefined;
 };
 
 /**
  * The event object that is passed into the lambda that the aws-durable-lambda
  * passes into the long running lambda handler.
  */
-export type TaskEvent = {
+export type TaskEvent<PayloadType = unknown> = {
   /**
    * The unique ID of the aws-durable-lambda task that triggered the lambda.
    * Used to retrieve the status and result of the task.
    */
   readonly taskId: string;
+
+  /**
+   * The optional body passed into the submitTask function.
+   */
+  requestPayload: PayloadType | undefined;
 };
 
 /**


### PR DESCRIPTION
The examples didn't have any type specified for the event passed in by the orchestrator when the task was run.

Types are now exported which the consumer of the plugin can use to write a handler of the correct type to use with the plugin.